### PR TITLE
Prettyprint long default values on multiple lines in the documentation.

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.8.1
+elixir 1.10.3

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ If extra information is required about the configuration specification to write 
 
 ## Changelog
 
+- 0.7.1 - Pretty-prints long default values in a multi-line code block in the documentation (#2).
 - 0.7 - Adds an `optional` key to the built-in providers. They will only return `{error, :not_found}` if they are not set to optional. Also adds two new ways to indicate sources, which are helpful in environments where you do not have access to the structs directly (such as `Mix.Config` or the newer `Elixir.Config` files.)
 - 0.6 - Adds the `mfa` and `function` builtin parsers.
 - 0.5 - Adds the `nonnegative_integer`, `positive_integer`, `nonnegative_float`, `positive_float` and `timeout` builtin parsers.

--- a/lib/specify.ex
+++ b/lib/specify.ex
@@ -419,7 +419,7 @@ defmodule Specify do
 
         ### #{name}
 
-        #{documentation || "ASDF"}
+        #{documentation}
 
         #{parser_doc(parser, original_parser)}
         """
@@ -429,7 +429,7 @@ defmodule Specify do
             {:ok, val} ->
               """
               #{doc}
-              Defaults to `#{inspect(val)}`.
+              Defaults to#{clever_prettyprint(val)}
               """
 
             :error ->
@@ -450,6 +450,23 @@ defmodule Specify do
 
     #{acc}
     """
+  end
+
+  # Render a multiline Markdown code block if `value` is large enough
+  # to be pretty-printed across multiple lines.
+  # otherwise, render an inline Markdown code block.
+  defp clever_prettyprint(value) do
+    inspected = Kernel.inspect(value, printable_limit: :infinity, limit: :infinity, width: 80, pretty: true)
+    if String.contains?(inspected, "\n") do
+      """
+      :
+      ```
+      #{inspected}
+      ```
+      """
+    else
+      " `#{inspected}`."
+    end
   end
 
   defp parser_doc(parser, original_parser) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Specify.MixProject do
   def project do
     [
       app: :specify,
-      version: "0.7.0",
+      version: "0.7.1",
       elixir: "~> 1.7",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,12 +1,12 @@
 %{
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.5", "0db71c8290b5bc81cb0101a2a507a76dca659513984d683119ee722828b424f6", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.1", "5ac36660846967cd869255f4426467a11672fec3d8db602c429425ce5b613b90", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.4", "4821b8d05cda507189d51f2caeef370cf1e18ca5d7dfb7d31e9cafe6688106a4", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.21.3", "857ec876b35a587c5d9148a2512e952e24c24345552259464b98bfbb883c7b42", [:mix], [{:earmark, "~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "inch_ex": {:hex, :inch_ex, "2.0.0", "24268a9284a1751f2ceda569cd978e1fa394c977c45c331bb52a405de544f4de", [:mix], [{:bunt, "~> 0.2", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
-  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.2.1", "12b22825e22f468c02eb3e4b9985f3d0cb8dc40b9bd704730efa11abd2708c44", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "makeup": {:hex, :makeup, "1.0.1", "82f332e461dc6c79dbd82fbe2a9c10d48ed07146f0a478286e590c83c52010b5", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
-  "stream_data": {:hex, :stream_data, "0.4.3", "62aafd870caff0849a5057a7ec270fad0eb86889f4d433b937d996de99e3db25", [:mix], [], "hexpm"},
+  "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Prettyprint long default values on multiple lines in the documentation.
Bumps version to 0.7.1.

Fixes #2