### PR TITLE
Make function clickable in generated doc

### DIFF
--- a/lib/specify.ex
+++ b/lib/specify.ex
@@ -460,7 +460,7 @@ defmodule Specify do
   defp clever_prettyprint(f) when is_function(f) do
     "&" <> f_str = inspect(f)
 
-    "`#{f_str}`"
+    "`#{f_str}`."
   end
 
   defp clever_prettyprint(value) do

--- a/lib/specify.ex
+++ b/lib/specify.ex
@@ -455,6 +455,14 @@ defmodule Specify do
   # Render a multiline Markdown code block if `value` is large enough
   # to be pretty-printed across multiple lines.
   # otherwise, render an inline Markdown code block.
+  # Functions are an exception: there are always on their own line to
+  # make then clickable.
+  defp clever_prettyprint(f) when is_function(f) do
+    "&" <> f_str = inspect(f)
+
+    "`#{f_str}`"
+  end
+
   defp clever_prettyprint(value) do
     inspected = Kernel.inspect(value, printable_limit: :infinity, limit: :infinity, width: 80, pretty: true)
     if String.contains?(inspected, "\n") do


### PR DESCRIPTION
Another proposal: in the current state a function is preceded by a "&" character, which is not recognized by ex_doc.

This PR removes it so that functions become automatically clickable and linked to the function in generated docs.

There should not be anonymous functions, which is why this case is not handled.