### PR TITLE
Added support for list of terms

### DIFF
--- a/lib/specify/parsers.ex
+++ b/lib/specify/parsers.ex
@@ -206,7 +206,7 @@ defmodule Specify.Parsers do
   end
 
   def list(binary, elem_parser) when is_binary(binary) do
-    case Code.string_to_quoted(binary, existing_atoms_only: true) do
+    case string_to_term(binary, existing_atoms_only: true) do
       {:ok, list_ast} when is_list(list_ast) ->
         list_ast
         |> Enum.map(&Macro.expand(&1, __ENV__))
@@ -253,12 +253,10 @@ defmodule Specify.Parsers do
   Will also check and ensure that this function is actually defined.
   """
   def mfa(raw) when is_binary(raw) do
-    case Code.string_to_quoted(raw) do
-      {:ok, {:{}, _meta, [qmodule, qfunction, arity]}} ->
-        with {:ok, module} <- unquote_atom(qmodule),
-             {:ok, function} <- unquote_atom(qfunction) do
-          mfa({module, function, arity})
-        end
+    case string_to_term(raw) do
+      {:ok, {module, function, arity}}
+        when is_atom(module) and is_atom(function) and is_integer(arity) ->
+        mfa({module, function, arity})
       {:ok, _other} ->
         {:error, "`#{inspect(raw)}`, while parseable as Elixir code, does not represent a Module-Function-Arity tuple."}
       {:error, reason} ->
@@ -323,4 +321,33 @@ defmodule Specify.Parsers do
   def function(other) do
     {:error, "`#{other}` cannot be parsed as a function."}
   end
+
+  defp string_to_term(binary, opts \\ []) when is_binary(binary) do
+    case Code.string_to_quoted(binary, opts) do
+      {:ok, ast} ->
+        {:ok, ast_to_term(ast)}
+
+      {:error, _} = error ->
+        error
+    end
+  rescue
+    e ->
+      {:error, e}
+  end
+
+  defp ast_to_term(term) when is_atom(term), do: term
+  defp ast_to_term(term) when is_integer(term), do: term
+  defp ast_to_term(term) when is_float(term), do: term
+  defp ast_to_term(term) when is_binary(term), do: term
+  defp ast_to_term([]), do: []
+  defp ast_to_term([h | t]), do: [ast_to_term(h) | ast_to_term(t)]
+  defp ast_to_term({a, b}), do: {ast_to_term(a), ast_to_term(b)}
+  defp ast_to_term({:{}, _place, terms}),
+    do: terms |> Enum.map(&ast_to_term/1) |> List.to_tuple()
+  defp ast_to_term({:%{}, _place, terms}),
+    do: for {k, v} <- terms, into: %{}, do: {ast_to_term(k), ast_to_term(v)}
+  defp ast_to_term(aliased = {:__aliases__, _, _}), do: Macro.expand(aliased, __ENV__)
+  defp ast_to_term({:+, _, [number]}), do: number
+  defp ast_to_term({:-, _, [number]}), do: -number
+  defp ast_to_term(ast), do: raise ArgumentError, message: "invalid term `#{inspect(ast)}`"
 end

--- a/lib/specify/parsers.ex
+++ b/lib/specify/parsers.ex
@@ -206,7 +206,7 @@ defmodule Specify.Parsers do
   end
 
   def list(binary, elem_parser) when is_binary(binary) do
-    case string_to_term(binary, existing_atoms_only: true) do
+    case string_to_term(binary) do
       {:ok, list_ast} when is_list(list_ast) ->
         list_ast
         |> Enum.map(&Macro.expand(&1, __ENV__))
@@ -322,7 +322,7 @@ defmodule Specify.Parsers do
     {:error, "`#{other}` cannot be parsed as a function."}
   end
 
-  defp string_to_term(binary, opts \\ []) when is_binary(binary) do
+  defp string_to_term(binary, opts \\ [existing_atoms_only: true]) when is_binary(binary) do
     case Code.string_to_quoted(binary, opts) do
       {:ok, ast} ->
         {:ok, ast_to_term(ast)}


### PR DESCRIPTION
In its current form, Specify uses `Code.string_to_quoted/1` to parse list terms when the option is provided as a string.

It returns an AST which make it possible to parse simple values (such as integers) but not complex values such as tuples or maps.

This PR adds support for parsing terms of any complexity (maps of arrays of maps...). It doesn't, however, allow parsing anything (`->` for instance will still return an error when parsed).

One question is: do we want that? One use case I have in mind is to provide JSON web keys with private keys through env vars, so I'd say yes (it looks like: `"%{\"crv\" => \"P-256\", \"d\" => \"_wdq-xnEtZ8vI_eaPRPbKjDFCtxBcvDjDGCGZezWPU4\", \"kty\" => \"EC\", \"x\" => \"gRhNKb9c68dnEro0XWHuRlbbAqH9qhzbLV-uD5iLdPU\", \"y\" => \"mw7rGB-fKXu0pb-9vH7h3xFhvo4qE8ei_6LQRNF1gdU\"}"`).

This is also preparatory work for options, whose second element is an arbitrary term (unless we don't want it to be loaded from a string).

Also note that in the test file, atom is not added to the generators because it creates non-existing atoms. An issue was opened here: https://github.com/whatyouhide/stream_data/issues/141