### PR TITLE
Multi-parsers implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ Cosette.CastleOnACloud.load
     (specify) lib/specify.ex:147: Specify.load/2
 ```
 
+### Multiple parsers
+
+It is possible to specify several parsers for a unique field, using a list of parsers. They
+will be tried consecutively in list order. For instance:
+
+```elixir
+field :some_field, [:string, :boolean], default: true
+```
+
 ### Loading from Sources
 
 Loading from another source is easy:

--- a/test/specify_test.exs
+++ b/test/specify_test.exs
@@ -65,7 +65,7 @@ defmodule SpecifyTest do
                  require Specify
 
                  Specify.defconfig do
-                   field(:name, default: "Slatibartfast")
+                   field(:name, :string, default: "Slatibartfast")
                  end
                end
              end) =~
@@ -161,6 +161,33 @@ defmodule SpecifyTest do
         assert_raise(MyCustomError, fn ->
           ParsingExample.load_explicit([size: thing], parsing_error: MyCustomError)
         end)
+      end
+    end
+  end
+
+  describe "multi-parser is properly called" do
+    defmodule MultiParserExample do
+      require Specify
+
+      Specify.defconfig do
+        @doc false
+        field(:value, [:integer, :float, :boolean], default: "13.37")
+      end
+    end
+
+    test "Parser is called with default" do
+      assert MultiParserExample.load() == %MultiParserExample{value: 13.37}
+    end
+
+    property "parser is called with value" do
+      check all thing <- term() do
+        if is_integer(thing) or is_float(thing) or is_boolean(thing) do
+          assert %MultiParserExample{value: thing} = MultiParserExample.load_explicit(value: thing)
+        else
+          assert_raise(Specify.ParsingError, fn ->
+            MultiParserExample.load_explicit(value: thing)
+          end)
+        end
       end
     end
   end


### PR DESCRIPTION
A proposal for multi-parsers, in relation to #9.

Contrary to your proposal, I have not opted for a `one_of([:parser1, :parser2...])` approach but rather using lists for the following reasons:
- I'm unsure one_of would semantically be a parser per se
- I think it'd require important refactoring, due to how the `construct_parser/1` works in conjunction with `normalize_parser/2` in `specify.ex`. The first function would have to call again the second one that was already executed
- the semantics of a list is IMO very natural and clear for developers (it does what one expect it to do)

Also note that a generic error is returned. Maybe it could be improved by adding all the parsing errors to the result error, but I'm unsure how it could prove useful.