### PR TITLE
List parser: accept any term

### DIFF
--- a/lib/specify/parsers.ex
+++ b/lib/specify/parsers.ex
@@ -221,6 +221,10 @@ defmodule Specify.Parsers do
     end
   end
 
+  def list(term, _) do
+    {:error, "`#{inspect(term)}` does not represent an Elixir list."}
+  end
+
   @doc """
   Allows to pass in a 'timeout' which is a common setting for OTP-related features,
   accepting either a positive integer, or the atom `:infinity`.


### PR DESCRIPTION
Fixes a bug with list parser that threw an exception when term was not recognized (such as an atom) instead of returning a error tuple